### PR TITLE
fix: Change deprecated settings for lazygit

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,6 +1,6 @@
 gui:
   language: 'ja'
-  showIcons: true
+  nerdFontsVersion: '3'
 
 os:
   editPreset: 'vscode'


### PR DESCRIPTION
[Deprecated config `showIcons`](https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#display-nerd-fonts-icons)